### PR TITLE
configure-edge-device-log

### DIFF
--- a/IoTEdgeDevice/files/etc/docker/daemon.json
+++ b/IoTEdgeDevice/files/etc/docker/daemon.json
@@ -1,0 +1,7 @@
+{
+    "log-driver": "json-file",
+    "log-opts": {
+        "max-size": "10m",
+        "max-file": "3"
+    }
+}


### PR DESCRIPTION
#39

https://docs.microsoft.com/ja-jp/azure/iot-edge/production-checklist#option-set-global-limits-that-apply-to-all-container-modules